### PR TITLE
feat: add acceptContract to CommercialService

### DIFF
--- a/src/Services/CommercialService.php
+++ b/src/Services/CommercialService.php
@@ -296,6 +296,14 @@ readonly class CommercialService
             ]);
     }
 
+    public function acceptContract(int $contractId): Collection
+    {
+        return $this->http
+            ->withUrlParameters(['contractId' => $contractId])
+            ->get('ws/comercial/contratos/aceite/{contractId}')
+            ->collect();
+    }
+
     public function attachFilesToProspect(int $prospectId, int $userId, array $files): Response
     {
         $payload = collect($files)->map(function (UploadedFile $file, $key) use ($prospectId, $userId) {


### PR DESCRIPTION
## Summary

- Implements `CommercialService::acceptContract(int $contractId): Collection`
- Calls `GET /ws/comercial/contratos/aceite/{idContrato}`

## Test plan

- [ ] Call `Telco::commercial()->acceptContract($contractId)` with a valid contract ID and verify the response is collected correctly